### PR TITLE
adds helmet middlewares

### DIFF
--- a/generators/app/template/package.json
+++ b/generators/app/template/package.json
@@ -16,6 +16,7 @@
     "goodeggs-logger": "*",
     "goodeggs-stats": "*",
     "gulp": "*",
+    "helmet": "^0.10.0",
     "keymirror": "^0.1.1",
     "lodash": "^3.7.0",
     "once-upon": "*",

--- a/generators/app/template/src/app.coffee
+++ b/generators/app/template/src/app.coffee
@@ -5,6 +5,7 @@ logger = require 'goodeggs-logger'
 stats = require 'goodeggs-stats'
 assets = require 'goodeggs-assets'
 express = require 'express'
+helmet = require 'helmet'
 
 settings = require './server/modules/settings'
 fetchr = require 'app-services/fetchr'
@@ -12,6 +13,10 @@ domainServices = require 'domain-services'
 
 server = null
 app = express()
+
+app.use helmet.hidePoweredBy()
+app.use helmet.noCache()
+app.use helmet.frameguard()
 
 app.use logger.middleware.request
 app.use assets.middleware()


### PR DESCRIPTION
by default, we now add the hidePoweredBy, noCache, and frameguard
middlewares from https://github.com/helmetjs/helmet

others are excluded because they have subtle but important impacts on
edge caching (xssFilter would require us to vary on User-Agent, not just
X-UA-Device; contentSecurityPolicy misconfiguration can easily break your site)

fixes #1 
/cc @demands @adborden
